### PR TITLE
Adding support for Socket connections to Slack instead of RTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,22 @@ If you want to kick the tires, we would love feedback. Check out these two examp
 
 - [simple.go](https://github.com/GrantStreetGroup/go-slackbot/blob/master/examples/simple/simple.go)
 - [wit.go](https://github.com/GrantStreetGroup/go-slackbot/blob/master/examples/wit/wit.go).
+
+## Events API SocketMode support
+
+To enable SocketMode support over RTM use
+
+    bot := slackbot.New(token, ...options)
+    bot.EventMode = "Socket"
+
+
+
+
+## ReactionEvent
+
+Bot can respond to the use of reactions in a slack message stream.
+
+    bot.ReactTo("reaction").ReactionHandler(handlerfunc)
+
+
+    

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ If you want to kick the tires, we would love feedback. Check out these two examp
 
 ## Events API SocketMode support
 
-To enable SocketMode support over RTM use
+To enable SocketMode support over RTM you need an AppLevelToken for your bot app
 
-    bot := slackbot.New(token, ...options)
+    bot := slackbot.New(token, slack.OptionAppLevelToken(app), ...options)
     bot.EventMode = "Socket"
-
+	...
 
 
 

--- a/bot.go
+++ b/bot.go
@@ -44,6 +44,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
 )
 
 const (
@@ -56,6 +57,7 @@ const (
 // New constructs a new Bot using the slackToken to authorize against the Slack service.
 func New(slackToken string, options ...slack.Option) *Bot {
 	b := &Bot{Client: slack.New(slackToken, options...)}
+	b.EventMode = "RTM"
 	return b
 }
 
@@ -66,13 +68,25 @@ type Bot struct {
 	// Slack UserID of the bot UserID
 	botUserID string
 	// Slack API
-	Client *slack.Client
-	RTM    *slack.RTM
-	Debug  bool
+	Client    *slack.Client
+	RTM       *slack.RTM
+	Socket    *socketmode.Client
+	Debug     bool
+	EventMode string
 }
 
-// Run listens for incoming slack RTM events, matching them to an appropriate handler.
+// Run listeners for incoming slack events via RTM or Socketmode, matching them to an appropriate handler.
 func (b *Bot) Run() {
+
+	if b.EventMode == "RTM" {
+		b.RunRTM()
+	} else {
+		b.RunSocketMode()
+	}
+}
+
+// Run listeners for incoming slack RTM events, matching them to an appropriate handler.
+func (b *Bot) RunRTM() {
 	b.RTM = b.Client.NewRTM()
 	go b.RTM.ManageConnection()
 	for {
@@ -86,7 +100,7 @@ func (b *Bot) Run() {
 			switch ev := msg.Data.(type) {
 			case *slack.ConnectedEvent:
 				fmt.Printf("Connected: %#v\n", ev.Info.User)
-				b.setBotID(ev.Info.User.ID)
+				b.SetBotID(ev.Info.User.ID)
 			case *slack.MessageEvent:
 				// ignore messages from the current user, the bot user
 				if b.botUserID == ev.User {
@@ -152,10 +166,14 @@ func (b *Bot) Run() {
 
 // Reply replies to a message event with a simple message.
 func (b *Bot) Reply(evt *slack.MessageEvent, msg string, typing bool) {
-	if typing {
-		b.Type(evt, msg)
+	if b.EventMode == "RTM" {
+		if typing {
+			b.Type(evt, msg)
+		}
+		b.RTM.SendMessage(b.RTM.NewOutgoingMessage(msg, evt.Channel))
+	} else {
+		b.Client.PostMessage(evt.Channel, slack.MsgOptionText(msg, true), slack.MsgOptionAsUser(true))
 	}
-	b.RTM.SendMessage(b.RTM.NewOutgoingMessage(msg, evt.Channel))
 }
 
 // ReplyWithAttachments replys to a message event with a Slack Attachments message.
@@ -184,7 +202,7 @@ func (b *Bot) BotUserID() string {
 	return b.botUserID
 }
 
-func (b *Bot) setBotID(ID string) {
+func (b *Bot) SetBotID(ID string) {
 	b.botUserID = ID
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/GrantStreetGroup/go-slackbot
+module github.com/ArcticSnowman/go-slackbot
 
-go 1.21
+go 1.23
 
 require (
 	github.com/chris-skud/go-wit v0.0.0-20160116012338-c5c44784af9f

--- a/socket.go
+++ b/socket.go
@@ -23,6 +23,7 @@ func (b *Bot) RunSocketMode() {
 			ctx = AddBotToContext(ctx, b)
 			if b.Debug {
 				ctx = SetDebug(ctx)
+				log.Printf("Event Type: %s", evt.Type)
 			}
 
 			switch evt.Type {
@@ -33,6 +34,8 @@ func (b *Bot) RunSocketMode() {
 				fmt.Println("Connection failed. Retrying later...")
 			case socketmode.EventTypeConnected:
 				fmt.Println("Connected to Slack with Socket Mode.")
+			case socketmode.EventTypeHello:
+				fmt.Println("Slack says hello")
 			case socketmode.EventTypeEventsAPI:
 				eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
 				if !ok {

--- a/socket.go
+++ b/socket.go
@@ -191,6 +191,11 @@ func ConvertReactionAdded(evt *slackevents.ReactionAddedEvent) *slack.ReactionAd
 		ItemUser:       evt.ItemUser,
 		Reaction:       evt.Reaction,
 		EventTimestamp: evt.EventTimestamp,
+		Item: slack.ReactionItem{
+			Type:      evt.Item.Type,
+			Channel:   evt.Item.Channel,
+			Timestamp: evt.Item.Timestamp,
+		},
 	}
 
 	return &react
@@ -204,6 +209,11 @@ func ConvertReactionRemoved(evt *slackevents.ReactionRemovedEvent) *slack.Reacti
 		ItemUser:       evt.ItemUser,
 		Reaction:       evt.Reaction,
 		EventTimestamp: evt.EventTimestamp,
+		Item: slack.ReactionItem{
+			Type:      evt.Item.Type,
+			Channel:   evt.Item.Channel,
+			Timestamp: evt.Item.Timestamp,
+		},
 	}
 
 	return &react

--- a/socket.go
+++ b/socket.go
@@ -1,0 +1,204 @@
+package slackbot
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+	"golang.org/x/net/context"
+)
+
+func (b *Bot) RunSocketMode() {
+
+	b.Socket = socketmode.New(b.Client, socketmode.OptionDebug(b.Debug))
+
+	go func() {
+		for evt := range b.Socket.Events {
+			ctx := context.Background()
+			ctx = AddBotToContext(ctx, b)
+			if b.Debug {
+				ctx = SetDebug(ctx)
+			}
+
+			switch evt.Type {
+			case socketmode.EventTypeConnecting:
+				fmt.Println("Connecting to Slack with Socket Mode...")
+				// conn := evt.Data.(socketmode.ConnectedEvent)\
+			case socketmode.EventTypeConnectionError:
+				fmt.Println("Connection failed. Retrying later...")
+			case socketmode.EventTypeConnected:
+				fmt.Println("Connected to Slack with Socket Mode.")
+			case socketmode.EventTypeEventsAPI:
+				eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
+				if !ok {
+					fmt.Printf("Ignored %+v\n", evt)
+					continue
+				}
+
+				fmt.Printf("Event received: %+v\n", eventsAPIEvent)
+
+				b.Socket.Ack(*evt.Request)
+
+				switch eventsAPIEvent.Type {
+				case slackevents.CallbackEvent:
+					innerEvent := eventsAPIEvent.InnerEvent
+					switch ev := innerEvent.Data.(type) {
+					case *slackevents.MessageEvent:
+						if b.botUserID == ev.User {
+							continue
+						}
+						ctx = AddMessageToContext(ctx, b.ConvertMessageEvent(ev))
+						var match RouteMatch
+						if matched, ctx := b.Match(ctx, &match); matched {
+							match.Handler(ctx)
+						}
+					case *slackevents.ReactionAddedEvent:
+						// Handle reaction events
+						if b.botUserID == ev.User {
+							continue
+						}
+
+						ctx = AddReactionAddedToContext(ctx, ConvertReactionAdded(ev))
+						var match RouteMatch
+						if matched, ctx := b.Match(ctx, &match); matched {
+							match.Handler(ctx)
+						}
+
+					case *slackevents.ReactionRemovedEvent:
+						// Handle reaction events
+						if b.botUserID == ev.User {
+							continue
+						}
+
+						ctx = AddReactionRemovedToContext(ctx, ConvertReactionRemoved(ev))
+						var match RouteMatch
+						if matched, ctx := b.Match(ctx, &match); matched {
+							match.Handler(ctx)
+						}
+
+					}
+				default:
+					b.Socket.Debugf("unsupported Events API event received")
+				}
+			case socketmode.EventTypeInteractive:
+				// callback, ok := evt.Data.(slack.InteractionCallback)
+				// if !ok {
+				// 	fmt.Printf("Ignored %+v\n", evt)
+
+				// 	continue
+				// }
+
+				// fmt.Printf("Interaction received: %+v\n", callback)
+
+				// var payload interface{}
+
+				// switch callback.Type {
+				// case slack.InteractionTypeBlockActions:
+				// 	// See https://api.slack.com/apis/connections/socket-implement#button
+
+				// 	client.Debugf("button clicked!")
+				// case slack.InteractionTypeShortcut:
+				// case slack.InteractionTypeViewSubmission:
+				// 	// See https://api.slack.com/apis/connections/socket-implement#modal
+				// case slack.InteractionTypeDialogSubmission:
+				// default:
+
+				// }
+
+				// client.Ack(*evt.Request, payload)
+			case socketmode.EventTypeSlashCommand:
+				// cmd, ok := evt.Data.(slack.SlashCommand)
+				// if !ok {
+				// 	fmt.Printf("Ignored %+v\n", evt)
+
+				// 	continue
+				// }
+
+				// client.Debugf("Slash command received: %+v", cmd)
+
+				// payload := map[string]interface{}{
+				// 	"blocks": []slack.Block{
+				// 		slack.NewSectionBlock(
+				// 			&slack.TextBlockObject{
+				// 				Type: slack.MarkdownType,
+				// 				Text: "foo",
+				// 			},
+				// 			nil,
+				// 			slack.NewAccessory(
+				// 				slack.NewButtonBlockElement(
+				// 					"",
+				// 					"somevalue",
+				// 					&slack.TextBlockObject{
+				// 						Type: slack.PlainTextType,
+				// 						Text: "bar",
+				// 					},
+				// 				),
+				// 			),
+				// 		),
+				// 	}}
+
+				// client.Ack(*evt.Request, payload)
+			default:
+				fmt.Fprintf(os.Stderr, "Unexpected event type received: %s\n", evt.Type)
+			}
+		}
+	}()
+
+	b.Socket.Run()
+}
+
+func (b *Bot) ConvertMessageEvent(evt *slackevents.MessageEvent) *slack.MessageEvent {
+
+	msg := slack.MessageEvent{
+		Msg: slack.Msg{
+			ClientMsgID:     evt.ClientMsgID,
+			Type:            evt.Type,
+			User:            evt.User,
+			Text:            evt.Text,
+			ThreadTimestamp: evt.ThreadTimeStamp,
+			Timestamp:       evt.TimeStamp,
+			Channel:         evt.Channel,
+			// ChannelType
+			EventTimestamp: evt.EventTimeStamp,
+			// UserTeam
+			// SourceTeam
+			SubType:  evt.SubType,
+			BotID:    evt.BotID,
+			Username: evt.Username,
+			Icons:    (*slack.Icon)(evt.Icons),
+			Upload:   evt.Upload,
+			// Files:    evt.Files,
+
+		},
+	}
+
+	return &msg
+}
+
+func ConvertReactionAdded(evt *slackevents.ReactionAddedEvent) *slack.ReactionAddedEvent {
+
+	react := slack.ReactionAddedEvent{
+		Type:           evt.Type,
+		User:           evt.User,
+		ItemUser:       evt.ItemUser,
+		Reaction:       evt.Reaction,
+		EventTimestamp: evt.EventTimestamp,
+	}
+
+	return &react
+}
+
+func ConvertReactionRemoved(evt *slackevents.ReactionRemovedEvent) *slack.ReactionRemovedEvent {
+
+	react := slack.ReactionRemovedEvent{
+		Type:           evt.Type,
+		User:           evt.User,
+		ItemUser:       evt.ItemUser,
+		Reaction:       evt.Reaction,
+		EventTimestamp: evt.EventTimestamp,
+	}
+
+	return &react
+}

--- a/socket.go
+++ b/socket.go
@@ -2,6 +2,7 @@ package slackbot
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/slack-go/slack"
@@ -12,7 +13,9 @@ import (
 
 func (b *Bot) RunSocketMode() {
 
-	b.Socket = socketmode.New(b.Client, socketmode.OptionDebug(b.Debug))
+	b.Socket = socketmode.New(b.Client,
+		socketmode.OptionDebug(b.Debug),
+		socketmode.OptionLog(log.New(os.Stdout, "socketmode: ", log.Lshortfile|log.LstdFlags)))
 
 	go func() {
 		for evt := range b.Socket.Events {


### PR DESCRIPTION
Adding support for Socket connections to Slack instead of RTM 

This would allow a bot to use the more up to date custom app rather than the old style RTM Hubot app.